### PR TITLE
Custom audit description and changes to composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To create the tables you can use the CakePHP 3.0 Migrations shell. Here is how:
 
 1. Copy the migrations from `/path/to/plugin/config/Migrations` to your `src/config/Migrations/` directory
    
-> If you installed via composer you need to look at `vendor/jippi/cakephp-audit-log/config/Migrations`, if you installed the plugin manually you should look under `plugins/AuditLog/config/Migrations`
+> If you installed via composer you need to look at `vendor/creditdatamw/cakephp-audit-log/config/Migrations`, if you installed the plugin manually you should look under `plugins/AuditLog/config/Migrations`
    
 2. run the migrations with the following command
 
@@ -63,6 +63,34 @@ Applying the `AuditableBehavior` to a model is essentially the same as applying 
       
     }
 ```
+
+### Describing events
+
+> NOTE: Since version `1.1.0` 
+
+You may want to add a custom description message for an Audit Event from your application.
+You can do this by setting the `Auditable.auditDescription` attribute in the current request's 
+Session. The plugin reads the value from that and sets it in the `description` field for the 
+Audit record. The value is cleared upon use.
+
+Example:
+
+```php
+  public function delete($id=null) {
+    $session = $this->request()->session();
+
+    $post = $this->Posts->get($id);
+    
+    $title = $post->get('title');
+    
+    $session->write('Auditable.auditDescription', __('User deleted a Post with title={0}', $title));
+    
+    $this->Posts->delete($post);
+    
+    return $this->redirect('/');
+  }
+```
+ 
 
 ### Configuration
     

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name":"zikani03/cakephp-audit-log",
+  "name":"creditdatamw/cakephp-audit-log",
   "version": "1.0.0",
   "description":"A logging plugin for CakePHP. It takes a snapshot of the fully hydrated object after a change is complete and it also records each individual change in the case of an update action",
   "type":"cakephp-plugin",
@@ -11,19 +11,24 @@
     "logging",
     "plugin"
   ],
-  "homepage":"https://github.com/zikani03/cakephp-audit-log",
+  "homepage":"https://github.com/creditdatamw/cakephp-audit-log",
   "license":"MIT",
   "authors":[
     {
       "name":"Christian Winther",
       "role":"Author",
       "homepage":"http://cakephp.nu/"
+    },
+    {
+      "name":"Credit Data CRB Ltd",
+      "role":"Author",
+      "homepage":"https://www.creditdatamw.com/"
     }
   ],
   "support":{
-    "source":"https://github.com/zikani03/cakephp-audit-log",
-    "issues":"https://github.com/zikani03/cakephp-audit-log/issues",
-    "irc":"irc://irc.freenode.org/friendsofcake"
+    "source":"https://github.com/creditdatamw/cakephp-audit-log",
+    "issues":"https://github.com/creditdatamw/cakephp-audit-log/issues",
+    "irc":"irc://irc.freenode.org/cakephp"
   },
   "require":{
     "composer/installers":"*",

--- a/src/Model/Table/CurrentUserTrait.php
+++ b/src/Model/Table/CurrentUserTrait.php
@@ -9,11 +9,19 @@ trait CurrentUserTrait
     {
         $request = Request::createFromGlobals();
         $session = $request->session();
+        $username = $session->read('Auth.User.username');
+
+        if ($session->check('Auditable.auditDescription')) {
+            $description = $session->consume('Auditable.auditDescription');
+        } else {
+            $description = h(sprintf('Action by %s', $username));
+        }
+
         return [
-            'id' => $session->read('Auth.User.username'),
+            'id' => $username,
             'ip' => $request->env('REMOTE_ADDR'),
             'url' => $request->here(),
-            'description' => $session->read('Auth.User.username'),
+            'description' => $description,
         ];
     }
 }

--- a/tests/TestCase/Model/Table/CurrentUserTraitTest.php
+++ b/tests/TestCase/Model/Table/CurrentUserTraitTest.php
@@ -1,0 +1,66 @@
+<?php
+namespace AuditLog\Test\TestCase\Model\Table;
+
+use AuditLog\Model\Table\CurrentUserTrait;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use Cake\TestSuite\IntegrationTestCase;
+
+// Some hacks to ensure the functionality we want from cake works 
+define('TMP', tempnam(sys_get_temp_dir(), 'audit_log_test_session'));
+
+// Start the session
+session_start();
+
+/**
+ * Utility class used for testing the trait
+ */
+class ImplementsCurrentUser {
+    use CurrentUserTrait;
+}
+
+/**
+ * Tests for the CurrentUserTrait
+ *
+ */
+class CurrentUserTraitTest extends TestCase
+{
+    public function setUp()
+    {
+        // \Cake\Network\Request::createFromGlobals() expects an application configuration 
+        // to be present. We lie to cake that it does, here.. ;)
+        Configure::write('App', [
+            'name' => 'testApp',
+        ]);
+    }
+
+    public function testCurrentUserMethodExists()
+    {
+        $fakeModel = new ImplementsCurrentUser();
+        $this->assertTrue(method_exists($fakeModel, 'currentUser'));
+    }
+
+    public function testCurrentUserReturnsArray()
+    {
+        $fakeModel = new ImplementsCurrentUser();
+        $data = $fakeModel->currentUser();
+        $this->assertArrayHasKey('id', $data);
+        $this->assertArrayHasKey('ip', $data);
+        $this->assertArrayHasKey('url', $data);
+        $this->assertArrayHasKey('description', $data);
+    }
+
+    public function testModifyingDescription()
+    {
+        $expected = 'This item is no longer relevant';
+
+        $_SESSION['Auditable'] = [
+            'auditDescription' => 'This item is no longer relevant'
+        ];
+
+        $fakeModel = new ImplementsCurrentUser();
+        $data = $fakeModel->currentUser();
+
+        $this->assertEquals($expected, $data['description']);
+    }
+}


### PR DESCRIPTION
Allow users to set a custom description for the audit event and updated `composer.json` to change name of the project.